### PR TITLE
End-user container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .*
 *
+!.git
 !*.bash
 !*.bats
 !bin/*

--- a/.github/workflows/publish-end-user-images.yml
+++ b/.github/workflows/publish-end-user-images.yml
@@ -1,0 +1,61 @@
+name: Build & publish end-user images
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  TAG_PREFIX: ghcr.io/${{ github.repository }}
+
+jobs:
+  container_images:
+    name: Build & publish end-user images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
+
+      - name: Log in to the container registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ ${GITHUB_REF:?} =~ ^refs/tags/v([0-9].*)$ ]]; then
+            tag_version=BASH_REMATCH[1]
+          else
+            # use the default in docker-bake.hcl
+            tag_version=''
+          fi
+          echo "tag_version=${tag_version?}" | tee -a "${GITHUB_OUTPUT:?}"
+
+          push=false
+          if [[ ${GITHUB_REF:?} =~ ^refs/tags/v[0-9]|^refs/heads/main$ ]]; then
+            push=true
+          fi
+          echo "push=${push:?}" | tee -a "${GITHUB_OUTPUT:?}"
+
+      - name: Build & publish
+        uses: docker/bake-action@f32f8b8d70bc284af19f8148dd14ad1d2fbc6c28
+        env:
+          JSON_BASH_VERSION: ${{ steps.version.outputs.tag_version }}
+        with:
+          targets: pkg,jb
+          files: docker-bake.hcl
+          provenance: true
+          sbom: true
+          push: ${{ steps.version.outputs.push }}
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG TESH_SOURCE TEST_OS TAG_BASE TEST_ENV_TAG=__not_set__ CI
+# syntax=docker/dockerfile:1.6
+ARG TESH_SOURCE TEST_OS TAG_BASE TEST_ENV_TAG=__not_set__ CI BAKE_LOCAL_PLATFORM
 
 
 FROM alpine:latest AS alpine-bash-from-src
@@ -76,3 +77,129 @@ COPY --from=run-bats /workspace/build .
 
 FROM scratch AS result-tesh
 COPY --from=run-tesh /workspace/build .
+
+
+# fpm creates all sorts of package-manager packages https://fpm.readthedocs.io/
+FROM ruby:3 AS fpm
+RUN gem install fpm
+
+
+FROM fpm as pkg-setup
+SHELL ["bash", "-euo", "pipefail", "-c"]
+WORKDIR /pkg-src
+COPY --from=repo --chmod=755 --chown=root \
+  json.bash bin/jb-cat bin/jb-echo bin/jb-stream bin/
+RUN cd bin && for prog in jb jb-array; do ln -s json.bash "${prog:?}"; done
+ARG JSON_BASH_VERSION
+RUN --mount=from=repo,target=/repo <<EOF
+JSON_BASH_SOURCE_VERSION=$(. bin/json.bash; echo "${JSON_BASH_VERSION:?}")
+
+# If we're releasing then require that the src and build versions match
+if [[ ${JSON_BASH_VERSION:?} =~ [0-9]+\.[0-9]+\.[0-9] ]]; then
+  if [[ ${JSON_BASH_VERSION} != ${JSON_BASH_SOURCE_VERSION:?} ]]; then
+    echo "Error build version does not match source version: ${JSON_BASH_VERSION@A} ${JSON_BASH_SOURCE_VERSION@Q}" >&2
+    exit 1
+  fi
+fi
+
+SOURCE_DATE_EPOCH_DEFAULT=$(git -C /repo show -s --format=%at HEAD)
+
+echo -n "\
+--input-type dir
+--name json.bash
+--license MIT
+--version '${JSON_BASH_VERSION:?}'
+--architecture all
+--depends bash
+--description 'Command-line tool and bash library that creates JSON'
+--url 'https://github.com/h4l/json.bash'
+--maintainer 'Hal Blackburn'
+--source-date-epoch-default '${SOURCE_DATE_EPOCH_DEFAULT:?}'
+
+bin/json.bash=/usr/bin/json.bash
+bin/jb=/usr/bin/jb
+bin/jb-array=/usr/bin/jb-array
+bin/jb-cat=/usr/bin/jb-cat
+bin/jb-echo=/usr/bin/jb-echo
+bin/jb-stream=/usr/bin/jb-stream
+" > .fpm
+EOF
+
+FROM fpm AS pkg
+ARG JSON_BASH_VERSION
+ENV JSON_BASH_VERSION="${JSON_BASH_VERSION:?}"
+
+LABEL org.opencontainers.image.url="https://github.com/h4l/json.bash" \
+  org.opencontainers.image.version="${JSON_BASH_VERSION:?}" \
+  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.title="json.bash package builder" \
+  org.opencontainers.image.description="Build package-manager packages for json.bash using FPM"
+
+WORKDIR /pkg
+COPY --from=pkg-setup /pkg-src /pkg-src
+COPY --chmod=755 <<"EOF" /docker-entrypoint.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" == 0 || " $* " == *" --help "* ]]; then
+  echo "\
+Generate json.bash packages for common package managers.
+
+Examples:
+  # generate .deb and .rpm package files in the working directory
+  $ docker run -v $(pwd):/pkg ghcr.io/h4l/json.bash/pkg deb rpm
+
+  # Get a bash shell instead of generating packages
+  $ docker run -it ghcr.io/h4l/json.bash/pkg bash
+
+Usage:
+  ghcr.io/h4l/json.bash/pkg <package-type>...
+  ghcr.io/h4l/json.bash/pkg [--help]
+
+Info:
+  Package sources are in /pkg-src. To generate a package manually:
+    $ cd /pkg-src
+    $ fpm --output-type deb --package /pkg/json.bash.deb
+"
+  exit
+fi
+if [[ "${1:-}" == "bash" ]]; then
+  exec bash
+fi
+
+out_dir=$(pwd)
+cd /pkg-src
+log_file=$(mktemp)
+for type in "$@"; do
+  pkg_filename="${out_dir:?}/json.bash_${JSON_BASH_VERSION:?}.${type:?}"
+  if [[ -f "${pkg_filename:?}" ]]; then
+    echo "Skipping existing: ${pkg_filename:?}"
+    continue;
+  fi
+  echo "Generating: ${pkg_filename:?}"
+  fpm_args=(fpm --output-type "${type:?}" --package "${pkg_filename:?}")
+  if ! { "${fpm_args[@]:?}" > "${log_file:?}" 2>&1; }; then
+    echo "Failed to generate package by executing: ${fpm_args[@]@Q}" >&2
+    cat "${log_file:?}" >&2
+  fi
+done
+EOF
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+
+FROM --platform=${BAKE_LOCAL_PLATFORM:?} pkg AS pkg-alpine
+RUN /docker-entrypoint.sh apk
+
+
+FROM bash:latest AS jb
+ARG JSON_BASH_VERSION
+
+LABEL org.opencontainers.image.url="https://github.com/h4l/json.bash" \
+  orgopencontainers.image.version="${JSON_BASH_VERSION:?}" \
+  orgopencontainers.image.licenses="MIT" \
+  orgopencontainers.image.title="json.bash" \
+  org.opencontainers.image.description="Command-line tool and bash library that creates JSON"
+
+RUN --mount=from=pkg-alpine,source=/pkg,target=/pkg \
+  apk add --allow-untrusted /pkg/json.bash_*.apk
+ENTRYPOINT ["/usr/bin/jb"]


### PR DESCRIPTION
This PR adds two container image builds:

- `ghcr.io/h4l/json.bash/pkg` — a container that builds package-manager packages for json.bash (somewhat meta ...)
- `ghcr.io/h4l/json.bash/jb` — json.bash with jb-* executables, based on the official bash image 